### PR TITLE
Update Makefiles to support building manylinux2014_aarch64 wheels

### DIFF
--- a/builtins/packagedcode_msitools-linux/Makefile
+++ b/builtins/packagedcode_msitools-linux/Makefile
@@ -6,6 +6,13 @@
 # See https://aboutcode.org for more information about nexB OSS projects.
 #
 
+ARCH := $(shell uname -m)
+ifeq ($(ARCH),aarch64)
+	PLAT_NAME := "manylinux2014_aarch64"
+else
+	PLAT_NAME := "manylinux1_x86_64"
+endif
+
 clean:
 	rm -rf build/ dist/
 	find . -type f -name '*.py[co]' -delete -o -type d -name __pycache__ -delete
@@ -14,6 +21,6 @@ build:
 	rm -f src/packagedcode_msitools/bin/msi*
 	python setup.py clean --all sdist
 	rm -f src/packagedcode_msitools/bin/msi*
-	python setup.py clean --all bdist_wheel --python-tag py3 --plat-name manylinux1_x86_64
+	python setup.py clean --all bdist_wheel --python-tag py3 --plat-name $(PLAT_NAME)
 
 .PHONY: clean build

--- a/builtins/rpm_inspector_rpm/Makefile
+++ b/builtins/rpm_inspector_rpm/Makefile
@@ -9,10 +9,8 @@
 ARCH := $(shell uname -m)
 ifeq ($(ARCH),aarch64)
 	PLAT_NAME := "manylinux2014_aarch64"
-	GOARCH := "arm64"
 else
 	PLAT_NAME := "manylinux1_x86_64"
-	GOARCH := "amd64"
 endif
 
 clean:
@@ -20,15 +18,8 @@ clean:
 	find . -type f -name '*.py[co]' -delete -o -type d -name __pycache__ -delete
 
 build:
-	rm -f src/fetchcode_container/bin/skopeo*
+	rm -f src/rpm_inspector_rpm/bin/rpm
 	python setup.py clean --all sdist
-	rm -f src/fetchcode_container/bin/skopeo*
-	GOOS=linux GOARCH=$(GOARCH) python setup.py clean --all bdist_wheel --python-tag py3 --plat-name $(PLAT_NAME)
-#	rm -f src/fetchcode_container/bin/skopeo*
-#	GOOS=darwin GOARCH=amd64 python setup.py clean --all bdist_wheel --python-tag py3 --plat-name macosx_10_14_x86_64
-#	rm -f src/fetchcode_container/bin/skopeo*
-#	GOOS=windows GOARCH=amd64 python setup.py clean --all bdist_wheel --python-tag py3 --plat-name win_amd64
-
+	python setup.py clean --all bdist_wheel --python-tag py3 --plat-name $(PLAT_NAME)
 
 .PHONY: clean build
-


### PR DESCRIPTION
This PR updates the Makefiles of fetchcode_container, packagedcode_msitools-linux, and rpm_inspector_rpm to be able to be built on aarch64 systems